### PR TITLE
[feature] :(#22) add filter vehicle workshop for appointment

### DIFF
--- a/crm/crm/doctype/appointment/appointment.js
+++ b/crm/crm/doctype/appointment/appointment.js
@@ -65,6 +65,9 @@ crm.Appointment = class Appointment extends crm.QuickContacts {
 			if (!this.frm.is_new()) {
 				filters["appointment"] = this.frm.doc.name;
 			}
+			if (this.frm.doc.vehicle_workshop) {
+				filters["vehicle_workshop"] = this.frm.doc.vehicle_workshop;
+			}
 
 			return {
 				query: "crm.crm.doctype.appointment.appointment.appointment_sales_person_query",

--- a/crm/crm/doctype/appointment/appointment.js
+++ b/crm/crm/doctype/appointment/appointment.js
@@ -65,9 +65,6 @@ crm.Appointment = class Appointment extends crm.QuickContacts {
 			if (!this.frm.is_new()) {
 				filters["appointment"] = this.frm.doc.name;
 			}
-			if (this.frm.doc.vehicle_workshop) {
-				filters["vehicle_workshop"] = this.frm.doc.vehicle_workshop;
-			}
 
 			return {
 				query: "crm.crm.doctype.appointment.appointment.appointment_sales_person_query",

--- a/crm/crm/doctype/appointment/appointment.py
+++ b/crm/crm/doctype/appointment/appointment.py
@@ -986,7 +986,7 @@ def appointment_sales_person_query(doctype, txt, searchfield, start, page_len, f
 
 	appointment_type = filters.pop("appointment_type", None)
 	allowed_sales_persons = get_allowed_sales_persons(appointment_type)
-	vehicle_workshop = filters.pop("vehicle_workshop", None)
+
 	appointment = filters.pop("appointment", None)
 	scheduled_dt = filters.pop("scheduled_dt", None)
 	end_dt = filters.pop("end_dt", None)
@@ -1012,10 +1012,10 @@ def appointment_sales_person_query(doctype, txt, searchfield, start, page_len, f
 
 	if allowed_sales_persons:
 		sales_person_conditions = "`tabSales Person`.name in %(allowed_sales_persons)s"
+		fcond = ""
 	else:
 		sales_person_conditions = "`tabSales Person`.is_group = 0"
-		if vehicle_workshop:
-			sales_person_conditions += f" AND `tabSales Person`.vehicle_workshop = '{vehicle_workshop}'"
+		fcond = get_filters_cond(doctype, filters, conditions)
 
 	out = frappe.db.sql("""
 		select `tabSales Person`.name {availability_field} {fields}
@@ -1032,7 +1032,7 @@ def appointment_sales_person_query(doctype, txt, searchfield, start, page_len, f
 		'fields': fields_str,
 		"scond": searchfields,
 		'key': searchfield,
-		'fcond': get_filters_cond(doctype, filters, conditions),
+		'fcond': fcond,
 		'mcond': get_match_cond(doctype),
 		'sales_person_conditions': sales_person_conditions,
 		'availability_field': availability_field,

--- a/crm/crm/doctype/appointment/appointment.py
+++ b/crm/crm/doctype/appointment/appointment.py
@@ -986,7 +986,7 @@ def appointment_sales_person_query(doctype, txt, searchfield, start, page_len, f
 
 	appointment_type = filters.pop("appointment_type", None)
 	allowed_sales_persons = get_allowed_sales_persons(appointment_type)
-
+	vehicle_workshop = filters.pop("vehicle_workshop", None)
 	appointment = filters.pop("appointment", None)
 	scheduled_dt = filters.pop("scheduled_dt", None)
 	end_dt = filters.pop("end_dt", None)
@@ -1014,6 +1014,8 @@ def appointment_sales_person_query(doctype, txt, searchfield, start, page_len, f
 		sales_person_conditions = "`tabSales Person`.name in %(allowed_sales_persons)s"
 	else:
 		sales_person_conditions = "`tabSales Person`.is_group = 0"
+		if vehicle_workshop:
+			sales_person_conditions += f" AND `tabSales Person`.vehicle_workshop = '{vehicle_workshop}'"
 
 	out = frappe.db.sql("""
 		select `tabSales Person`.name {availability_field} {fields}


### PR DESCRIPTION
PR Description
Updates to Sales Person DocType:
Added a new custom field called Vehicle Workshop, positioned below the Branch field.

Made the Vehicle Workshop field read-only when an Employee is selected.

Implemented logic to force-set the Branch field if a Vehicle Workshop is selected without an Employee being selected.

Updates to Repair Order DocType:
When a Vehicle Workshop is selected, the Service Advisor field is filtered based on the selected Vehicle Workshop.

Added a condition on Vehicle Workshop for filtering the Service Advisor.

Closes [](https://github.com/ParaLogicTech/automotive/issues/22)