### PR TITLE
[feature]: (#15) Sales Person is optional for appointment

### DIFF
--- a/crm/crm/doctype/appointment/appointment.py
+++ b/crm/crm/doctype/appointment/appointment.py
@@ -250,12 +250,9 @@ class Appointment(StatusUpdater):
 
 		# Check if appointment source allows non-mandatory sales person
 		if self.appointment_source:
-			try:
-				source_doc = frappe.get_cached_doc("Appointment Source", self.appointment_source)
-				if getattr(source_doc, "sales_person_non_mandatory", 0):
-					return  # Skip mandatory validation if checkbox is checked
-			except Exception:
-				pass  # Fallback to normal validation if source not found or error
+			sales_person_non_mandatory = frappe.get_cached_value("Appointment Source", self.appointment_source, "sales_person_non_mandatory")
+			if sales_person_non_mandatory:
+				return
 
 		appointment_type_doc = frappe.get_cached_doc("Appointment Type", self.appointment_type)
 		if not self.sales_person and appointment_type_doc.sales_person_mandatory:

--- a/crm/crm/doctype/appointment/appointment.py
+++ b/crm/crm/doctype/appointment/appointment.py
@@ -248,6 +248,15 @@ class Appointment(StatusUpdater):
 		if not self.appointment_type:
 			return
 
+		# Check if appointment source allows non-mandatory sales person
+		if self.appointment_source:
+			try:
+				source_doc = frappe.get_cached_doc("Appointment Source", self.appointment_source)
+				if getattr(source_doc, "sales_person_non_mandatory", 0):
+					return  # Skip mandatory validation if checkbox is checked
+			except Exception:
+				pass  # Fallback to normal validation if source not found or error
+
 		appointment_type_doc = frappe.get_cached_doc("Appointment Type", self.appointment_type)
 		if not self.sales_person and appointment_type_doc.sales_person_mandatory:
 			frappe.throw(_("{0} is mandatory for appointment confirmation").format(self.meta.get_label("sales_person")))

--- a/crm/crm/doctype/appointment_source/appointment_source.json
+++ b/crm/crm/doctype/appointment_source/appointment_source.json
@@ -11,7 +11,8 @@
   "section_break_wv6px",
   "details",
   "column_break_hqney",
-  "disable_automated_notifications"
+  "disable_automated_notifications",
+  "sales_person_non_mandatory"
  ],
  "fields": [
   {
@@ -40,6 +41,12 @@
    "fieldname": "disable_automated_notifications",
    "fieldtype": "Check",
    "label": "Disable Automated Notifications"
+  },
+  {
+   "default": "0",
+   "fieldname": "sales_person_non_mandatory",
+   "fieldtype": "Check",
+   "label": "Sales Person Non-Mandatory for Confirmation"
   }
  ],
  "links": [],


### PR DESCRIPTION
**PR Description:**

This PR introduces a feature where the service advisor (salesperson) field is not mandatory if the associated appointment source has the sales_person_non_mandatory flag enabled.

**Implementation:**

- A new checkbox, sales_person_non_mandatory, has been added to the appointment source settings. By default, this checkbox is unchecked.
- When the checkbox is enabled for any appointment source, the service advisor field becomes optional when creating an appointment.

![image](https://github.com/user-attachments/assets/5826bcc1-e16f-4e04-926f-9a6ccedfaff1)

Closes [](https://github.com/ParaLogicTech/crm/issues/15)