### PR TITLE
[feature]: (#18) Show available service advisors

### DIFF
--- a/crm/crm/doctype/appointment/appointment.py
+++ b/crm/crm/doctype/appointment/appointment.py
@@ -568,7 +568,7 @@ class Appointment(StatusUpdater):
 
 
 @frappe.whitelist()
-def get_appointment_timeslots(scheduled_date, appointment_type, appointment=None):
+def get_appointment_timeslots(scheduled_date, appointment_type, appointment=None, include_available_agents=False):
 	out = frappe._dict({
 		'holiday': None,
 		'timeslots': []
@@ -587,8 +587,19 @@ def get_appointment_timeslots(scheduled_date, appointment_type, appointment=None
 
 	if timeslots:
 		for timeslot_start, timeslot_end in timeslots:
-			appointments_in_slots = count_appointments_in_slot(timeslot_start, timeslot_end, appointment_type,
-				appointment)
+			appointments_available = get_appointments_in_slot(
+				timeslot_start,
+				timeslot_end,
+				appointment_type,
+				appointment
+			) or []
+			appointments_in_slots = len(appointments_available)
+
+			available_agents = get_allowed_sales_persons(appointment_type)
+
+			if include_available_agents:
+				booked_agents = {appointment.sales_person for appointment in appointments_available}
+				available_agents = [agent for agent in available_agents if agent not in booked_agents]
 
 			timeslot_data = {
 				'timeslot_start': timeslot_start,
@@ -598,6 +609,8 @@ def get_appointment_timeslots(scheduled_date, appointment_type, appointment=None
 				'booked': appointments_in_slots,
 				'available': max(0, no_of_agents - appointments_in_slots)
 			}
+			if include_available_agents:
+				timeslot_data['available_agents'] = available_agents
 			out.timeslots.append(timeslot_data)
 
 	elif timeslots is None:

--- a/crm/crm/doctype/appointment/appointment.py
+++ b/crm/crm/doctype/appointment/appointment.py
@@ -569,6 +569,8 @@ class Appointment(StatusUpdater):
 
 @frappe.whitelist()
 def get_appointment_timeslots(scheduled_date, appointment_type, appointment=None, include_available_agents=False):
+	include_available_agents = cint(include_available_agents)
+
 	out = frappe._dict({
 		'holiday': None,
 		'timeslots': []
@@ -587,30 +589,29 @@ def get_appointment_timeslots(scheduled_date, appointment_type, appointment=None
 
 	if timeslots:
 		for timeslot_start, timeslot_end in timeslots:
-			appointments_available = get_appointments_in_slot(
+			appointments_in_slot = get_appointments_in_slot(
 				timeslot_start,
 				timeslot_end,
-				appointment_type,
-				appointment
-			) or []
-			appointments_in_slots = len(appointments_available)
-
-			available_agents = get_allowed_sales_persons(appointment_type)
-
-			if include_available_agents:
-				booked_agents = {appointment.sales_person for appointment in appointments_available}
-				available_agents = [agent for agent in available_agents if agent not in booked_agents]
+				appointment_type=appointment_type,
+				appointment=appointment,
+			)
+			no_of_booked_slots = len(appointments_in_slot)
 
 			timeslot_data = {
 				'timeslot_start': timeslot_start,
 				'timeslot_end': timeslot_end,
 				'timeslot_duration': round((timeslot_end - timeslot_start) / datetime.timedelta(minutes=1)),
 				'number_of_agents': no_of_agents,
-				'booked': appointments_in_slots,
-				'available': max(0, no_of_agents - appointments_in_slots)
+				'booked': no_of_booked_slots,
+				'available': max(0, no_of_agents - no_of_booked_slots)
 			}
+
 			if include_available_agents:
+				allowed_sales_persons = get_allowed_sales_persons(appointment_type)
+				booked_agents = {app.sales_person for app in appointments_in_slot if app.sales_person}
+				available_agents = [agent for agent in allowed_sales_persons if agent not in booked_agents]
 				timeslot_data['available_agents'] = available_agents
+
 			out.timeslots.append(timeslot_data)
 
 	elif timeslots is None:
@@ -669,7 +670,7 @@ def get_appointments_in_slot(start_dt, end_dt, appointment_type=None, appointmen
 		'sales_person': sales_person,
 	}, as_dict=1)
 
-	return appointments
+	return appointments or []
 
 
 def auto_mark_missed():


### PR DESCRIPTION
Summary:

This PR introduces changes to include available service advisors when `get_appointment_timeslots` API is hit.

✅ What’s Implemented:

-  A new param include_available_agents has been added to the params list , default set to False.
- when user includes this in the request and set to true, a list of available advisors for a timeslot along with other details will be included in the response structure.

Sample response :

![image](https://github.com/user-attachments/assets/48e83726-89e5-46c3-aa24-5fa19d7c4807)



closes [](https://github.com/ParaLogicTech/crm/issues/18)