### PR TITLE
[feature]: (#45) Add checkbox to exclude flagged types in report

### DIFF
--- a/crm/crm/doctype/feedback_type/feedback_type.json
+++ b/crm/crm/doctype/feedback_type/feedback_type.json
@@ -16,7 +16,6 @@
   {
    "fieldname": "feedback_type",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Feedback Type",
    "reqd": 1,
    "unique": 1
@@ -26,14 +25,14 @@
    "fieldname": "feedback_sub_type_mandatory",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Feedback Sub Type mandatory"
+   "label": "Feedback Sub Type Mandatory"
   },
   {
    "default": "0",
    "fieldname": "feedback_status_mandatory",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Feedback Status mandatory"
+   "label": "Feedback Status Mandatory"
   },
   {
    "default": "0",
@@ -47,12 +46,12 @@
    "fieldname": "exclude_from_customer_feedback_index",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Exclude from Customer Feedback Index Report"
+   "label": "Exclude from Feedback Index Report"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-15 11:19:41.946063",
+ "modified": "2025-05-16 12:10:57.646711",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Feedback Type",

--- a/crm/crm/doctype/feedback_type/feedback_type.json
+++ b/crm/crm/doctype/feedback_type/feedback_type.json
@@ -9,7 +9,8 @@
   "feedback_type",
   "feedback_sub_type_mandatory",
   "feedback_status_mandatory",
-  "is_employee_required"
+  "is_employee_required",
+  "exclude_from_customer_feedback_index"
  ],
  "fields": [
   {
@@ -40,11 +41,18 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Is Employee Required"
+  },
+  {
+   "default": "0",
+   "fieldname": "exclude_from_customer_feedback_index",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Exclude from Customer Feedback Index Report"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-06 12:28:56.192971",
+ "modified": "2025-05-15 11:19:41.946063",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Feedback Type",


### PR DESCRIPTION
### **Description:**
---
Added a new checkbox field named exclude_from_feedback_index in the Feedback Type doctype. This field allows users to mark specific feedback types that should be excluded from the Customer Feedback Index report.


![image](https://github.com/user-attachments/assets/cd790f16-e246-4ffd-ad44-95b7d6b82dfa)

Closes [](https://github.com/ParaLogicTech/automotive/issues/45)